### PR TITLE
Adjust to elk 0.5.0 (include rectPacking algorithm)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ ext.versions = [
   emfGwt: '2.12.4',
   gwt:    '2.8.0',
   guava:  '21.0',
-  melk:   '0.5.0-SNAPSHOT',
-  xtext:  '2.12.0',
+  melk:   '0.5.0',
+  xtext:  '2.16.0',
 ]
 
 if (!hasProperty('elkRepo')) {
@@ -50,14 +50,17 @@ if (!hasProperty('elkRepo')) {
 }
 
 def elkSources = [
+  // The core and graph format
   "${elkRepo}/plugins/org.eclipse.elk.core/src",
   "${elkRepo}/plugins/org.eclipse.elk.graph/src",
   "${elkRepo}/plugins/org.eclipse.elk.graph.json/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.common/src",
+  // The algorithms
   "${elkRepo}/plugins/org.eclipse.elk.alg.disco/src",
-  "${elkRepo}/plugins/org.eclipse.elk.alg.layered/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.force/src",
+  "${elkRepo}/plugins/org.eclipse.elk.alg.layered/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.mrtree/src",
+  "${elkRepo}/plugins/org.eclipse.elk.alg.packing.rectangles/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.radial/src",
   "${elkRepo}/plugins/org.eclipse.elk.alg.spore/src"
 ]

--- a/src/java/org/eclipse/elk/js/ElkJs.java
+++ b/src/java/org/eclipse/elk/js/ElkJs.java
@@ -28,6 +28,7 @@ import org.eclipse.elk.alg.force.options.*;
 import org.eclipse.elk.alg.mrtree.options.*;
 import org.eclipse.elk.alg.radial.options.*;
 import org.eclipse.elk.alg.spore.options.*;
+import org.eclipse.elk.alg.packing.rectangles.options.*;
 
 /**
  * Entry point classes define <code>onModuleLoad()</code>.
@@ -98,7 +99,7 @@ public class ElkJs implements EntryPoint {
             // let it look like a regular message (add the 'data' key)
             function FakeWorker(url) {
                 var _this = this;
-                
+
                 // post messages
                 this.dispatcher = new Dispatcher({
                     postMessage: function(msg) { _this.onmessage({ data: msg }) }
@@ -143,6 +144,8 @@ public class ElkJs implements EntryPoint {
                 SERVICE.registerLayoutMetaDataProviders(new PolyominoOptions(), new DisCoMetaDataProvider());
             } else if (alg.equals("sporeOverlap") || alg.equals("sporeCompaction")) {
                 SERVICE.registerLayoutMetaDataProviders(new SporeMetaDataProvider());
+            } else if (alg.equals("rectPacking")) {
+                SERVICE.registerLayoutMetaDataProviders(new RectPackingMetaDataProvider());
             }
         }
     }

--- a/src/js/elk-api.js
+++ b/src/js/elk-api.js
@@ -9,7 +9,17 @@ export default class ELK {
 
   constructor({
     defaultLayoutOptions = {},
-    algorithms = [ 'layered', 'stress', 'mrtree', 'radial', 'force', 'disco', 'sporeOverlap', 'sporeCompaction' ],
+    algorithms = [
+        'layered',
+        'stress',
+        'mrtree',
+        'radial',
+        'force',
+        'disco',
+        'sporeOverlap',
+        'sporeCompaction',
+        'rectPacking'
+    ],
     workerFactory,
     workerUrl
   } = {}) {

--- a/test/mocha/testLayouters.js
+++ b/test/mocha/testLayouters.js
@@ -16,7 +16,7 @@ const graph = {
   children: [
     { id: 'n1', x: 20, y: 20, width: 10, height: 10 },
     { id: 'n2', x: 50, y: 50, width: 10, height: 10 }
-  ], 
+  ],
   edges: [{ id: 'e1', sources: [ 'n1' ], targets: [ 'n2' ]  }]
 }
 
@@ -33,10 +33,10 @@ describe('Layout Algorithms', function() {
 
   it('SPOrE Compaction', function() {
     return elk.layout(graph, {
-      layoutOptions: { 
-        'algorithm': 'elk.sporeCompaction', 
-        'elk.spacing.nodeNode': 14, 
-        'elk.padding': '[left=2, top=2, right=2, bottom=2]' 
+      layoutOptions: {
+        'algorithm': 'elk.sporeCompaction',
+        'elk.spacing.nodeNode': 14,
+        'elk.padding': '[left=2, top=2, right=2, bottom=2]'
       }
     }).should.eventually.be.fulfilled
       .then(function (graph) {
@@ -49,9 +49,9 @@ describe('Layout Algorithms', function() {
 
   it('SPOrE Overlap Removal', function() {
     return elk.layout(graphOverlapping, {
-      layoutOptions: { 
-        'algorithm': 'elk.sporeOverlap', 
-        'elk.spacing.nodeNode': 13, 
+      layoutOptions: {
+        'algorithm': 'elk.sporeOverlap',
+        'elk.spacing.nodeNode': 13,
         'elk.padding': '[left=3, top=3, right=3, bottom=3]' }
     }).should.eventually.be.fulfilled
       .then(function (graph) {
@@ -60,6 +60,14 @@ describe('Layout Algorithms', function() {
         expect(graph.children[1].x).to.equal(26)
         expect(graph.children[1].y).to.equal(26)
       })
+  })
+
+  it('Rectangle Packing', function() {
+    return elk.layout(graphOverlapping, {
+      layoutOptions: {
+        'algorithm': 'elk.rectPacking'
+      }
+    }).should.eventually.be.fulfilled
   })
 
 })


### PR DESCRIPTION
GWT compilation seems to work out of the box. As far as I could tell from the release notes and fixed issues, the `rectPacking` algorithm is the only new thing that requires manual addition into the elkjs code, right?

Btw: is it possible that the algorithm is rather slow? The mocha tests print a execution time warning for a graph with two nodes already. 

Sorry for the whitespace changes, they seem to be added by gitpod without being shown to the user ~.~. 