### PR TITLE
Added functionality to request ELK's logging and execution times

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,11 @@ to construct it:
 Apart from that the `ELK` offers the following methods:
 * `layout(graph, options)`
   * `graph` - the graph to be laid out in [ELK JSON](http://www.eclipse.org/elk/documentation/tooldevelopers/graphdatastructure/jsonformat.html). Mandatory!
-  * `options` - a configuration object. Currently its sole purpose is to pass _global_ layout options.
-    That is, layout options that are applied to every graph element unless the element specifies the option itself. Optional.
+  * `options` - a configuration object. Optional.
+    * `layoutOptions`: its most important purpose is to pass _global_ layout options.
+      That is, layout options that are applied to every graph element unless the element specifies the option itself.
+    * `logging`: boolean. Whether logging information shall be passed back as part of the laid out graph.
+    * `measureExecutionTime`: boolean. Whether execution time (in seconds) information shall be passed back as part of the laid out graph.
   * returns a `Promise`, which passes either the laid out graph on success or a (hopefully helpful) error on failure.
 * `knownLayoutOptions()`
   * returns an array of of known layout options. For each options additional information
@@ -203,6 +206,50 @@ Apart from that the `ELK` offers the following methods:
 The three methods starting with `known` basically return information
 that, in the Java world, would be retrieved from the [`LayoutMetaDataService`](http://www.eclipse.org/elk/documentation/algorithmdevelopers/metadatalanguage.html).
 
+
+# Logging and Execution Times
+ELK provides some means to log debug information during layout algorithm execution.
+The details can be found in the [_Algorithm Debugging_](https://www.eclipse.org/elk/documentation/algorithmdevelopers/algorithmdebugging.html) section of ELK's documentation.
+Not all of it is available in elkjs though, for instance, it is not possible to save intermediate results of the laid out graphs.
+Furthermore, while internally execution time is measured in _nanoseconds_ on the Java side,
+in elkjs we have to resort to _milliseconds_.
+Note that the returned execution times are in seconds.
+For small graphs this may often result in execution times being reported as `0`.
+
+See below an example call and the example output.
+```
+elk.layout(simpleGraph, {
+    layoutOptions: {
+        'algorithm': 'layered'
+    },
+    logging: true,
+    measureExecutionTime: true
+})
+```
+```
+{
+  "id": "root",
+  "children": [ ... ],
+  "edges": [ ... ],
+  "logging": {
+    "name": "Recursive Graph Layout",
+    "executionTime": 0.000096,
+    "children": [ {
+      "name": "Layered layout",
+      "logs": [
+        "ELK Layered uses the following 17 modules:",
+        "   Slot 01: org.eclipse.elk.alg.layered.p1cycles.GreedyCycleBreaker",
+            [ ... ]
+        "   Slot 16: org.eclipse.elk.alg.layered.intermediate.ReversedEdgeRestorer"
+      ],
+      "executionTime": 0.000072,
+      "children": [ { "name": "Greedy cycle removal", "executionTime": 0.000002 },
+                      [ ... ]
+                    { "name": "Restoring reversed edges", "executionTime": 0 } ]
+    } ]
+  }
+}
+```
 
 # Building
 

--- a/src/java/org/eclipse/elk/js/ElkJs.java
+++ b/src/java/org/eclipse/elk/js/ElkJs.java
@@ -70,7 +70,7 @@ public class ElkJs implements EntryPoint {
                         worker.postMessage({ id: data.id })
                         break
                     case 'layout':
-                        @org.eclipse.elk.js.ElkJs::layout(*)(data.graph, data.options || {})
+                        @org.eclipse.elk.js.ElkJs::layout(*)(data.graph, data.layoutOptions || {}, data.options || {})
                         worker.postMessage({ id: data.id, data: data.graph })
                         break
                 }
@@ -150,7 +150,9 @@ public class ElkJs implements EntryPoint {
         }
     }
 
-    public static void layout(final JavaScriptObject graphObj, final JavaScriptObject optionsObj) {
+    public static void layout(final JavaScriptObject graphObj,
+                              final JavaScriptObject layoutOptionsObj,
+                              final JavaScriptObject optionsObj) {
         // graph must exist
         JSONObject graph = new JSONObject(graphObj).isObject();
 
@@ -160,18 +162,87 @@ public class ElkJs implements EntryPoint {
         ElkNode elkGraph = importer.transform(graph);
 
         // apply global layout options
-        if (optionsObj != null) {
+        if (layoutOptionsObj != null) {
             // must be object
-            JSONObject options = new JSONObject(optionsObj).isObject();
+            JSONObject options = new JSONObject(layoutOptionsObj).isObject();
             LayoutConfigurator lc = optsToCfg(options);
             ElkUtil.applyVisitors(elkGraph, lc);
         }
 
-        new RecursiveGraphLayoutEngine().layout(elkGraph, new BasicProgressMonitor());
+        // check whether logging and/or execution time measurement shall be enabled
+        boolean recordLogs = false;
+        boolean recordExecutionTime = false;
+        if (optionsObj != null) {
+            JSONObject options = new JSONObject(optionsObj).isObject();
+            if (options.containsKey("logging")) {
+                recordLogs = options.get("logging").isBoolean().booleanValue();
+            }
+            if (options.containsKey("measureExecutionTime")) {
+                recordExecutionTime = options.get("measureExecutionTime").isBoolean().booleanValue();
+            }
+        }
 
+        // perform the layout
+        final BasicProgressMonitor pm = new BasicProgressMonitor()
+                                                .withLogging(recordLogs)
+                                                .withExecutionTimeMeasurement(recordExecutionTime);
+        new RecursiveGraphLayoutEngine().layout(elkGraph, pm);
+
+        // record the logs, possibly cleaning any old logging information
+        if (graph.containsKey("logging")) {
+            graph.put("logging", null);
+        }
+        if (recordLogs || recordExecutionTime) {
+            JSONObject logs = new JSONObject();
+            collectLogs(pm, logs, recordLogs, recordExecutionTime);
+            graph.put("logging", logs);
+        }
+
+        // transfer the computed layout to the input graph
         importer.transferLayout(elkGraph);
 
         // layout done, callback is called in js code
+    }
+
+    public static void collectLogs(final IElkProgressMonitor currentPM,
+                                   final JSONObject logObject,
+                                   final boolean recordLogs,
+                                   final boolean recordExecutionTime) {
+
+        // Set the name
+        final JSONString jsonTaskName = new JSONString(currentPM.getTaskName());
+        logObject.put("name", jsonTaskName);
+
+        // Collect the logs of the current progress monitor
+        if (recordLogs && !currentPM.getLogs().isEmpty()) {
+            final JSONArray jsonLogs = new JSONArray();
+            logObject.put("logs", jsonLogs);
+            int i = 0;
+            for (final String s : currentPM.getLogs()) {
+                final JSONString jsonString = new JSONString(s);
+                jsonLogs.set(i, jsonString);
+                i++;
+            }
+        }
+
+        // Record the execution time of the current progress monitor
+        if (recordExecutionTime) {
+            final JSONNumber jsonExecTime = new JSONNumber(currentPM.getExecutionTime());
+            logObject.put("executionTime", jsonExecTime);
+        }
+
+        // And process any child progress monitors
+        if (!currentPM.getSubMonitors().isEmpty()) {
+            final JSONArray children = new JSONArray();
+            logObject.put("children", children);
+            int i = 0;
+            for (final IElkProgressMonitor child : currentPM.getSubMonitors()) {
+                JSONObject jsonChild = new JSONObject();
+                children.set(i, jsonChild);
+                collectLogs(child, jsonChild, recordLogs, recordExecutionTime);
+                i++;
+            }
+        }
     }
 
     public static JavaScriptObject getLayoutAlgorithms() {

--- a/src/js/elk-api.js
+++ b/src/js/elk-api.js
@@ -55,14 +55,22 @@ export default class ELK {
       .catch(console.err)
   }
 
-  layout(graph, { layoutOptions = this.defaultLayoutOptions } = {}) {
+  layout(graph, {
+      layoutOptions = this.defaultLayoutOptions,
+      logging = false,
+      measureExecutionTime = false,
+  } = {}) {
     if (!graph) {
       return Promise.reject(new Error("Missing mandatory parameter 'graph'."))
     }
     return this.worker.postMessage({
       cmd: 'layout',
       graph: graph,
-      options: layoutOptions
+      layoutOptions: layoutOptions,
+      options: {
+          logging: logging,
+          measureExecutionTime: measureExecutionTime,
+      }
     })
   }
 

--- a/test/mocha/testLogging.js
+++ b/test/mocha/testLogging.js
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Kiel University and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+chai.should();
+
+var assert = chai.assert;
+var expect = chai.expect;
+
+const ELK = require('../../lib/main.js')
+const elk = new ELK()
+
+const simpleGraph = {
+    id: "root",
+    layoutOptions: { 'elk.direction': 'RIGHT' },
+    children: [
+        { id: "n1", width: 10, height: 10 },
+        { id: "n2", width: 10, height: 10 }
+    ],
+    edges: [{
+        id: "e1",
+        sources: [ "n1" ],
+        targets: [ "n2" ]
+    }]
+};
+
+describe('Logging', function() {
+
+  describe('#layout(...)', function() {
+
+    it('should provide logs if requested to.', function() {
+      return elk.layout(simpleGraph, {
+        layoutOptions: {
+          'algorithm': 'stress'
+        },
+        logging: true
+      })
+        .should.eventually.be.fulfilled
+        .then(function (graph) {
+          expect(graph.logging).not.to.be.undefined
+          // there should be at least one child ...
+          expect(graph.logging.children).not.to.be.undefined
+          // execution times should _not_ be included though
+          expect(graph.logging.executionTime).to.be.undefined
+        })
+    })
+
+    it('should not provide logs if not requested to.', function() {
+      return elk.layout(simpleGraph, {
+        logging: false
+      })
+        .should.eventually.be.fulfilled
+        .then(function (graph) {
+            expect(graph.logging).to.be.undefined
+        })
+    })
+
+    it('should provide execution times if requested to.', function() {
+      return elk.layout(simpleGraph, {
+        layoutOptions: {
+          'algorithm': 'layered'
+        },
+        measureExecutionTime: true
+      })
+        .should.eventually.be.fulfilled
+        .then(function (graph) {
+            expect(graph.logging).not.to.be.undefined
+            expect(graph.logging.executionTime).not.to.be.undefined
+        })
+    })
+
+    it('should not provide execution times if not requested to.', function() {
+      return elk.layout(simpleGraph, {
+        measureExecutionTime: false
+      })
+        .should.eventually.be.fulfilled
+        .then(function (graph) {
+            expect(graph.logging).to.be.undefined
+        })
+    })
+
+    it('should not provide logging information by default.', function() {
+      return elk.layout(simpleGraph)
+        .should.eventually.be.fulfilled
+        .then(function (graph) {
+            expect(graph.logging).to.be.undefined
+        })
+    })
+
+    it('should clear logging information from previous layout run.', function() {
+      // First execute with logging
+      return elk.layout(simpleGraph, {
+        logging: true
+      })
+        .should.eventually.be.fulfilled
+        .then(function (_) {
+            // Since the layout is applied in-place, 'simpleGraph' should contain the logging information
+            expect(simpleGraph.logging).not.to.be.undefined
+            return simpleGraph;
+        })
+        // Apply layout a second time without logging
+        .then(function(graph) {
+          return elk.layout(graph)
+        })
+        .should.eventually.be.fulfilled
+        .then(function (_) {
+          expect(simpleGraph.logging).to.be.undefined
+        })
+    })
+
+  })
+})


### PR DESCRIPTION
I added two parameters `logging: true` and `measureExecutionTime: true` to the API to request the corresponding information as generated by ELK. 

@le-cds Is it correct, that atm hardly any log information is written? So far I only saw the information of the BK placer and the slot configuration. 

Any other comments :)?